### PR TITLE
feat: response delay

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/caproven/mock-server/internal/rest"
 )
@@ -43,6 +44,7 @@ type Response struct {
 	StatusCode int               `yaml:"status"`
 	Headers    map[string]string `yaml:"headers"`
 	Body       ResponseBody      `yaml:"body"`
+	Delay      time.Duration     `yaml:"delay"`
 }
 
 type ResponseBody struct {
@@ -95,6 +97,10 @@ func (c Config) RestEndpoints() ([]*rest.Endpoint, error) {
 }
 
 func (r Response) toRest() (rest.Response, error) {
+	if r.Delay < 0 {
+		return rest.Response{}, errors.New("response delay cannot be negative")
+	}
+
 	if r.Body.Literal != "" && r.Body.FilePath != "" {
 		return rest.Response{}, errors.New("response body cannot use both literal and path")
 	}
@@ -112,6 +118,7 @@ func (r Response) toRest() (rest.Response, error) {
 		StatusCode: r.StatusCode,
 		Headers:    r.Headers,
 		Body:       respBody,
+		Delay:      r.Delay,
 	}
 
 	return resp, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,7 +101,10 @@ func (r Response) toRest() (rest.Response, error) {
 	if len(r.Delay) > 0 {
 		d, err := time.ParseDuration(r.Delay)
 		if err != nil {
-			return rest.Response{}, fmt.Errorf("invalid response delay: %q", r.Delay)
+			return rest.Response{}, fmt.Errorf("invalid response delay %q", r.Delay)
+		}
+		if d < 0 {
+			return rest.Response{}, errors.New("response delay cannot be negative")
 		}
 		respDelay = d
 	}

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -7,6 +7,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"sync"
+	"time"
 )
 
 type ResponseResolver interface {
@@ -135,6 +136,7 @@ type Response struct {
 	Headers    map[string]string
 	Body       []byte
 	StatusCode int
+	Delay      time.Duration
 }
 
 type httpMux interface {
@@ -157,6 +159,10 @@ func RegisterHandlers(mux httpMux, endpoints []*Endpoint) {
 			)
 
 			resp := endpoint.Response()
+
+			if resp.Delay != 0 {
+				time.Sleep(resp.Delay)
+			}
 
 			for header, val := range resp.Headers {
 				w.Header().Set(header, val)


### PR DESCRIPTION
Add field to response config for adding artificial delay when processing requests. Works with all response strategies